### PR TITLE
Add an IDestroyableGrain interface instead of using IAsyncDisposable

### DIFF
--- a/Wanderland.Web/Server/Grains/CreatorGrain.cs
+++ b/Wanderland.Web/Server/Grains/CreatorGrain.cs
@@ -69,7 +69,7 @@ public class CreatorGrain : Grain, ICreatorGrain
                     await _wanderlandHubContext.Clients.All.WorldListUpdated();
                     _worlds.State.Remove(remove);
                     var worldGrain = GrainFactory.GetGrain<IWorldGrain>(remove);
-                    await worldGrain.DisposeAsync();
+                    await worldGrain.OnDestroyWorld();
                 }
             }
 
@@ -142,7 +142,7 @@ public class CreatorGrain : Grain, ICreatorGrain
         await _wanderlandHubContext.Clients.All.WorldListUpdated();
         WorldsCompleted += 1;
 
-        await worldGrain.DisposeAsync();
+        await worldGrain.OnDestroyWorld();
     }
 
     public async Task GenerateNewWorld()

--- a/Wanderland.Web/Server/Grains/MonsterGrain.cs
+++ b/Wanderland.Web/Server/Grains/MonsterGrain.cs
@@ -75,7 +75,7 @@ public class MonsterGrain : WandererGrain, IMonsterGrain
     public async Task Eat(IWandererGrain grain)
     {
         Wanderer.State.AvatarImageUrl = MONSTER;
-        await grain.DisposeAsync();
+        await grain.OnDestroyWorld();
         await SpeedUp(4);
     }
 

--- a/Wanderland.Web/Server/Grains/WandererGrain.cs
+++ b/Wanderland.Web/Server/Grains/WandererGrain.cs
@@ -177,7 +177,7 @@ public class WandererGrain : Grain, IWandererGrain
         await SetLocation(nextTileGrain);
     }
 
-    public async ValueTask DisposeAsync()
+    public async ValueTask OnDestroyWorld()
     {
         _timer.Dispose();
 

--- a/Wanderland.Web/Server/Grains/WorldGrain.cs
+++ b/Wanderland.Web/Server/Grains/WorldGrain.cs
@@ -95,7 +95,7 @@ public class WorldGrain : Grain, IWorldGrain
         return Task.CompletedTask;
     }
 
-    public async ValueTask DisposeAsync()
+    public async ValueTask OnDestroyWorld()
     {
         foreach (var tile in _world.State.Tiles)
         {
@@ -104,11 +104,11 @@ public class WorldGrain : Grain, IWorldGrain
 
             if (tileGrain is not null)
             {
-                await tileGrain.DisposeAsync();
+                await tileGrain.OnDestroyWorld();
             }
         }
 
-        _timer.Dispose();
+        _timer?.Dispose();
         base.DeactivateOnIdle();
     }
 }

--- a/Wanderland.Web/Shared/Grains/IDestroyableGrain.cs
+++ b/Wanderland.Web/Shared/Grains/IDestroyableGrain.cs
@@ -1,0 +1,11 @@
+﻿using Orleans;
+
+namespace Wanderland.Web.Shared;
+
+public interface IDestroyableGrain : IGrain
+{
+    /// <summary>
+    /// Called when the resource should stop processing and clean itself up.
+    /// </summary>
+    ValueTask OnDestroyWorld();
+}

--- a/Wanderland.Web/Shared/Grains/ITileGrain.cs
+++ b/Wanderland.Web/Shared/Grains/ITileGrain.cs
@@ -2,7 +2,7 @@
 
 namespace Wanderland.Web.Shared;
 
-public interface ITileGrain : IGrainWithStringKey, IAsyncDisposable
+public interface ITileGrain : IGrainWithStringKey, IDestroyableGrain
 {
     Task SetTile(Tile tile);
     Task<Tile> GetTile();

--- a/Wanderland.Web/Shared/Grains/IWorldGrain.cs
+++ b/Wanderland.Web/Shared/Grains/IWorldGrain.cs
@@ -2,7 +2,7 @@
 
 namespace Wanderland.Web.Shared;
 
-public interface IWorldGrain : IGrainWithStringKey, IAsyncDisposable
+public interface IWorldGrain : IGrainWithStringKey, IDestroyableGrain
 {
     Task<World> GetWorld();
     Task SetTile(Tile tile);

--- a/Wanderland.Web/Shared/IWander.cs
+++ b/Wanderland.Web/Shared/IWander.cs
@@ -1,6 +1,6 @@
 ﻿namespace Wanderland.Web.Shared;
 
-public interface IWander : IAsyncDisposable
+public interface IWander : IDestroyableGrain
 {
     Task Wander();
     Task SetLocation(ITileGrain tileGrain);


### PR DESCRIPTION
Grains can be `IAsyncDisposable`/`IDisposable`, but Orleans will call those methods for you when the grain is no longer in use. Instead, use an abstraction to clean up state, timers, etc, and then tell the runtime to deactivate the grain (via `DeactivateOnIdle()`)